### PR TITLE
Feat : 전체 장바구니 목록, 특정 장바구니 조회

### DIFF
--- a/src/main/java/com/example/delivery/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/example/delivery/common/exception/enums/ErrorCode.java
@@ -26,11 +26,14 @@ public enum ErrorCode {
 
     // 404 - Not Found
     NOT_FOUND(404,HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),
-
+    USER_NOT_FOUND(404, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    CART_NOT_FOUND(404, HttpStatus.NOT_FOUND, "카트 목록을 찾을 수 없습니다."),
     // 500 - 서버 내부 오류
     INTERNAL_SERVER_ERROR(500,HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
-    TEST_ERROR(500,HttpStatus.INTERNAL_SERVER_ERROR, "테스트 에러입니다.");
+    TEST_ERROR(500,HttpStatus.INTERNAL_SERVER_ERROR, "테스트 에러입니다."),
 
+    // 주문
+    ACCESS_DENIED_CART(403, HttpStatus.FORBIDDEN, "본인의 장바구니만 조회할 수 있습니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/delivery/domain/menu/entity/Menu.java
+++ b/src/main/java/com/example/delivery/domain/menu/entity/Menu.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "menu")
 @Getter

--- a/src/main/java/com/example/delivery/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/delivery/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,10 @@
+package com.example.delivery.domain.menu.repository;
+
+import com.example.delivery.domain.menu.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+}

--- a/src/main/java/com/example/delivery/domain/order/controller/CartController.java
+++ b/src/main/java/com/example/delivery/domain/order/controller/CartController.java
@@ -1,0 +1,58 @@
+package com.example.delivery.domain.order.controller;
+
+import com.example.delivery.common.exception.base.CustomException;
+import com.example.delivery.common.exception.enums.SuccessCode;
+import com.example.delivery.common.response.ApiResponseDto;
+import com.example.delivery.domain.order.dto.Response.CartDetailResponseDto;
+import com.example.delivery.domain.order.dto.Response.CartsResponseDto;
+import com.example.delivery.domain.order.service.CartService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/delivery")
+@RequiredArgsConstructor
+public class CartController {
+    private final CartService cartService;
+
+    /**
+     * 전체 장바구니 목록
+     *
+     * @param userId 회원 ID
+     * @param httpServletRequest HttpServletRequest (요청 URI 정보)
+     * @return 회원의 전체 장바구니 목록
+     */
+    @GetMapping("/cart")
+    public ResponseEntity<ApiResponseDto<List<CartsResponseDto>>> getMyCartSummary(
+            @RequestParam Long userId,
+            HttpServletRequest httpServletRequest) {
+
+        List<CartsResponseDto> cartSummary = cartService.getMyCarts(userId);
+
+        return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.GET_SUCCESS, cartSummary, httpServletRequest.getRequestURI()));
+    }
+
+    /**
+     * 특정 장바구니 조회 API
+     *
+     * @param cartId   조회할 장바구니의 ID
+     * @param userId   본인의 장바구니인지 확인하는 ID
+     * @param httpServletRequest  HttpServletRequest (요청 URI 정보)
+     * @return 해당 장바구니의 상세 정보
+     * @throws CustomException CART_NOT_FOUND, NO_PERMISSION
+     */
+    @GetMapping("/cart/{cartId}")
+    public ResponseEntity<ApiResponseDto<CartDetailResponseDto>> getCartDetail(
+            @PathVariable Long cartId,
+            @RequestParam Long userId,
+            HttpServletRequest httpServletRequest ) {
+
+        CartDetailResponseDto cartDetail = cartService.getCartDetail(userId, cartId);
+
+        return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.GET_SUCCESS, cartDetail, httpServletRequest.getRequestURI()));
+    }
+}

--- a/src/main/java/com/example/delivery/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/delivery/domain/order/controller/OrderController.java
@@ -1,0 +1,16 @@
+package com.example.delivery.domain.order.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/delivery/order")
+@RequiredArgsConstructor
+public class OrderController {
+    // 주문
+
+    // 주문 상태
+
+    // 주문 상세 조회
+}

--- a/src/main/java/com/example/delivery/domain/order/dto/Response/CartDetailResponseDto.java
+++ b/src/main/java/com/example/delivery/domain/order/dto/Response/CartDetailResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.delivery.domain.order.dto.Response;
+
+import com.example.delivery.domain.order.entity.Cart;
+import com.example.delivery.domain.order.entity.CartItem;
+
+import java.util.List;
+
+public class CartDetailResponseDto {
+    private Long cartId;
+    private Long storeId;
+    private String storeName;
+    private List<CartItemDetailResponseDto> items;
+    private Long totalAmount;
+
+    public CartDetailResponseDto(Cart cart, List<CartItem> cartItems) {
+        this.cartId = cart.getId();
+        this.storeId = cart.getStore().getId();
+        this.storeName = cart.getStore().getStoreName();
+        this.items = cartItems.stream()
+                .map(CartItemDetailResponseDto::new)
+                .toList();
+        this.totalAmount = items.stream()
+                .mapToLong(CartItemDetailResponseDto::getTotalPrice)
+                .sum();
+    }
+}

--- a/src/main/java/com/example/delivery/domain/order/dto/Response/CartDetailResponseDto.java
+++ b/src/main/java/com/example/delivery/domain/order/dto/Response/CartDetailResponseDto.java
@@ -3,24 +3,35 @@ package com.example.delivery.domain.order.dto.Response;
 import com.example.delivery.domain.order.entity.Cart;
 import com.example.delivery.domain.order.entity.CartItem;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import java.util.List;
 
+@Getter
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class CartDetailResponseDto {
-    private Long cartId;
-    private Long storeId;
-    private String storeName;
-    private List<CartItemDetailResponseDto> items;
-    private Long totalAmount;
+    private final Long cartId;
+    private final Long storeId;
+    private final String storeName;
+    private final List<CartItemDetailResponseDto> items;
+    private final Long totalAmount;
 
-    public CartDetailResponseDto(Cart cart, List<CartItem> cartItems) {
-        this.cartId = cart.getId();
-        this.storeId = cart.getStore().getId();
-        this.storeName = cart.getStore().getStoreName();
-        this.items = cartItems.stream()
+    public static CartDetailResponseDto from(Cart cart, List<CartItem> cartItems) {
+        List<CartItemDetailResponseDto> items = cartItems.stream()
                 .map(CartItemDetailResponseDto::new)
                 .toList();
-        this.totalAmount = items.stream()
+
+        Long totalAmount = items.stream()
                 .mapToLong(CartItemDetailResponseDto::getTotalPrice)
                 .sum();
+
+        return new CartDetailResponseDto(
+                cart.getId(),
+                cart.getStore().getId(),
+                cart.getStore().getStoreName(),
+                items,
+                totalAmount
+        );
     }
 }

--- a/src/main/java/com/example/delivery/domain/order/dto/Response/CartItemDetailResponseDto.java
+++ b/src/main/java/com/example/delivery/domain/order/dto/Response/CartItemDetailResponseDto.java
@@ -1,16 +1,16 @@
 package com.example.delivery.domain.order.dto.Response;
 
 import com.example.delivery.domain.order.entity.CartItem;
-import lombok.Getter;
+import lombok.Value;
 
-@Getter
+@Value
 public class CartItemDetailResponseDto {
-    private Long menuId;
-    private String menuName;
-    private String intro;
-    private Long price;
-    private int quantity;
-    private Long totalPrice;
+    Long menuId;
+    String menuName;
+    String intro;
+    Long price;
+    int quantity;
+    Long totalPrice;
 
     public CartItemDetailResponseDto(CartItem item) {
         this.menuId = item.getMenu().getId();

--- a/src/main/java/com/example/delivery/domain/order/dto/Response/CartItemDetailResponseDto.java
+++ b/src/main/java/com/example/delivery/domain/order/dto/Response/CartItemDetailResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.delivery.domain.order.dto.Response;
+
+import com.example.delivery.domain.order.entity.CartItem;
+import lombok.Getter;
+
+@Getter
+public class CartItemDetailResponseDto {
+    private Long menuId;
+    private String menuName;
+    private String intro;
+    private Long price;
+    private int quantity;
+    private Long totalPrice;
+
+    public CartItemDetailResponseDto(CartItem item) {
+        this.menuId = item.getMenu().getId();
+        this.menuName = item.getMenu().getMenuName();
+        this.intro = item.getMenu().getIntro();
+        this.price = item.getMenu().getPrice();
+        this.quantity = item.getQuantity();
+        this.totalPrice = price * quantity;
+    }
+}

--- a/src/main/java/com/example/delivery/domain/order/dto/Response/CartsResponseDto.java
+++ b/src/main/java/com/example/delivery/domain/order/dto/Response/CartsResponseDto.java
@@ -2,15 +2,20 @@ package com.example.delivery.domain.order.dto.Response;
 
 import com.example.delivery.domain.order.entity.Cart;
 import com.example.delivery.domain.order.entity.CartItem;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CartsResponseDto {
-    private Long cartId;
-    private Long storeId;
-    private String storeName;
-    private String menuSummary; // 예: "불고기버거 외 2개"
-    private Long totalAmount;
+    private final Long cartId;
+    private final Long storeId;
+    private final String storeName;
+    private final String menuSummary; // 예: "불고기버거 외 2개"
+    private final Long totalAmount;
 
     // 장바구니에 담긴 메뉴 총 가격
     public CartsResponseDto(Cart cart, List<CartItem> cartItems) {

--- a/src/main/java/com/example/delivery/domain/order/dto/Response/CartsResponseDto.java
+++ b/src/main/java/com/example/delivery/domain/order/dto/Response/CartsResponseDto.java
@@ -1,0 +1,35 @@
+package com.example.delivery.domain.order.dto.Response;
+
+import com.example.delivery.domain.order.entity.Cart;
+import com.example.delivery.domain.order.entity.CartItem;
+
+import java.util.List;
+
+public class CartsResponseDto {
+    private Long cartId;
+    private Long storeId;
+    private String storeName;
+    private String menuSummary; // 예: "불고기버거 외 2개"
+    private Long totalAmount;
+
+    // 장바구니에 담긴 메뉴 총 가격
+    public CartsResponseDto(Cart cart, List<CartItem> cartItems) {
+        this.cartId = cart.getId();
+        this.storeId = cart.getStore().getId();
+        this.storeName = cart.getStore().getStoreName();
+        this.totalAmount = cartItems.stream()
+                .mapToLong(item -> item.getMenu().getPrice() * item.getQuantity())
+                .sum();
+
+        this.menuSummary = createMenuSummary(cartItems);
+    }
+
+    // 장바구니 메뉴 요약
+    private String createMenuSummary(List<CartItem> cartItems) {
+        String firstMenuName = cartItems.get(0).getMenu().getMenuName();
+
+        int extraCount = cartItems.size() - 1;
+
+        return extraCount > 0 ? firstMenuName + " 외 " + extraCount + "개" : firstMenuName;
+    }
+}

--- a/src/main/java/com/example/delivery/domain/order/entity/CartItem.java
+++ b/src/main/java/com/example/delivery/domain/order/entity/CartItem.java
@@ -2,11 +2,13 @@ package com.example.delivery.domain.order.entity;
 
 import com.example.delivery.domain.menu.entity.Menu;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "cartitem")
 @NoArgsConstructor
+@Getter
 public class CartItem {
 
     @Id
@@ -23,4 +25,5 @@ public class CartItem {
 
     @Column(nullable = false)
     private int quantity;
+
 }

--- a/src/main/java/com/example/delivery/domain/order/entity/Order.java
+++ b/src/main/java/com/example/delivery/domain/order/entity/Order.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "order")
+@Table(name = "orders")
 @Getter
 @NoArgsConstructor
 public class Order extends BaseEntity {

--- a/src/main/java/com/example/delivery/domain/order/repository/CartItemRepository.java
+++ b/src/main/java/com/example/delivery/domain/order/repository/CartItemRepository.java
@@ -1,0 +1,19 @@
+package com.example.delivery.domain.order.repository;
+
+import com.example.delivery.domain.menu.entity.Menu;
+import com.example.delivery.domain.order.entity.Cart;
+import com.example.delivery.domain.order.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    // 특정 장바구니에 담긴 모든 메뉴 항목을 리스트로 반환
+    List<CartItem> findByCart(Cart cart);
+
+    // 장바구니에 이미 담긴 메뉴인지 확인
+    Optional<CartItem> findByCartAndMenu(Cart cart, Menu menu);
+}

--- a/src/main/java/com/example/delivery/domain/order/repository/CartRepository.java
+++ b/src/main/java/com/example/delivery/domain/order/repository/CartRepository.java
@@ -1,0 +1,14 @@
+package com.example.delivery.domain.order.repository;
+
+import com.example.delivery.domain.order.entity.Cart;
+import com.example.delivery.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CartRepository extends JpaRepository<Cart, Long> {
+    // 유저의 장바구니 모두 리스트로 반환
+    List<Cart> findAllByUser(Long userId);
+}

--- a/src/main/java/com/example/delivery/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/delivery/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.example.delivery.domain.order.repository;
+
+
+public class OrderRepository {
+
+}
+

--- a/src/main/java/com/example/delivery/domain/order/service/CartService.java
+++ b/src/main/java/com/example/delivery/domain/order/service/CartService.java
@@ -1,0 +1,58 @@
+package com.example.delivery.domain.order.service;
+
+import com.example.delivery.common.exception.base.CustomException;
+import com.example.delivery.domain.menu.repository.MenuRepository;
+import com.example.delivery.domain.order.dto.Response.CartDetailResponseDto;
+import com.example.delivery.domain.order.dto.Response.CartsResponseDto;
+import com.example.delivery.domain.order.entity.Cart;
+import com.example.delivery.domain.order.entity.CartItem;
+import com.example.delivery.domain.order.repository.CartItemRepository;
+import com.example.delivery.domain.order.repository.CartRepository;
+import com.example.delivery.domain.store.repository.StoreRepository;
+import com.example.delivery.domain.user.entity.User;
+import com.example.delivery.domain.user.repository.UserRepository;
+import com.example.delivery.common.exception.enums.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CartService {
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final StoreRepository storeRepository;
+    private final MenuRepository menuRepository;
+    private final UserRepository userRepository;
+
+    // 유저가 가지고 있는 전체 장바구니 목록 조회
+    @Transactional(readOnly = true)
+    public List<CartsResponseDto> getMyCarts(Long userId) {
+        List<Cart> carts = cartRepository.findAllByUser(userId);
+
+        return carts.stream()
+                .map(cart -> {
+                    List<CartItem> cartItems = cartItemRepository.findByCart(cart);
+                    return new CartsResponseDto(cart, cartItems);
+                })
+                .toList();
+    }
+
+    // 특정 카트의 상세 정보 조회
+    @Transactional(readOnly = true)
+    public CartDetailResponseDto getCartDetail(Long userId, Long cartId) {
+        Cart cart = cartRepository.findById(cartId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        if (!cart.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.NO_PERMISSION);
+        }
+
+        List<CartItem> cartItems = cartItemRepository.findByCart(cart);
+
+        return new CartDetailResponseDto(cart, cartItems);
+    }
+}

--- a/src/main/java/com/example/delivery/domain/order/service/CartService.java
+++ b/src/main/java/com/example/delivery/domain/order/service/CartService.java
@@ -53,6 +53,7 @@ public class CartService {
 
         List<CartItem> cartItems = cartItemRepository.findByCart(cart);
 
-        return new CartDetailResponseDto(cart, cartItems);
+        return CartDetailResponseDto.from(cart, cartItems);
     }
+
 }

--- a/src/main/java/com/example/delivery/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/delivery/domain/order/service/OrderService.java
@@ -1,0 +1,4 @@
+package com.example.delivery.domain.order.service;
+
+public class OrderService {
+}

--- a/src/main/java/com/example/delivery/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/delivery/domain/store/repository/StoreRepository.java
@@ -1,0 +1,9 @@
+package com.example.delivery.domain.store.repository;
+
+import com.example.delivery.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/com/example/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/delivery/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.delivery.domain.user.repository;
+
+import com.example.delivery.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 # Redis set-up
 spring.data.redis.host=localhost
-spring.data.redis.port=6380
+spring.data.redis.port=6379
 
 # JWT secret key set-up (1hour, unit: millisecond, ms)
 jwt.secret=${SPRING_JWT_SECRET}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #7

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 장바구니 전체 목록 및 상세 조회 |
| 🔍 목적 | 사용자가 자산의 장바구니 목록을 조회하고, 특정 장바구니의 상세 정보를 확인할 수 있도록 함 |
| 🛠️ 변경사항 | `CartResponseDto`, `CartDetailResponseDto` 불변성 보장  |


## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | `/delivery/carts` 를 통한 전체 장바구니 목록 조회 API |
| 2️⃣ | `/delivery/carts` 를 통한 특정 장바구니 상세 조회 API |
| 3️⃣ | 장바구니 접근 권한 확인 로직 추가 (userId) 매칭 여부 체크 |
| 4️⃣ | `CartResponseDto`, `CartDetailResponseDto` Dto 구현 및 응답 구조 통일 |

## ✅ 테스트 체크리스트
- [x] 자신의 장바구니 목록이 정상적으로 조회되는지 확인

- [x] 타인의 장바구니에 접근할 경우 예외 발생 여부 확인

- [x] 응답 데이터에 총 금액, 스토어 정보, 메뉴 정보 등이 포함되어 있는지 확인

- [ ] API 명세서 및 Postman 테스트 완료

- [ ] 예외 응답 시 ErrorCode, message 정상 출력 확인
---

## 🙋‍♀️ 리뷰어 참고사항
- 추후 인증 방식이 토큰 기반으로 바뀌면 `userId` 파라미터 제거 예정
- 예외 처리 및 응답 포맷 통일성 유지에 중점
